### PR TITLE
提高sql执行效率

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -240,7 +240,7 @@ function postThumb($obj) {
 function Postviews($archive) {
 	$db = Typecho_Db::get();
 	$cid = $archive->cid;
-	if (!array_key_exists('views', $db->fetchRow($db->select()->from('table.contents')))) {
+	if (!array_key_exists('views', $db->fetchRow($db->select()->from('table.contents')->page(1,1)))) {
 		$db->query('ALTER TABLE `'.$db->getPrefix().'contents` ADD `views` INT(10) DEFAULT 0;');
 	}
 	$exist = $db->fetchRow($db->select('views')->from('table.contents')->where('cid = ?', $cid))['views'];


### PR DESCRIPTION
当文章数量达到上万条时，之前的sql查询会严重拖慢加载速度，故改成只查询一条数据进行判断